### PR TITLE
Create StudyPie timer interface

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,436 @@
+/*
+Non-negotiables:
+- Use requestAnimationFrame + performance.now(); compute elapsed from timestamps.
+- Interpolate visible ring proportions for smoothness; underlying totals remain exact.
+- Handle tab visibility changes; clamp dt to avoid stutters.
+- Buttons use transform/box-shadow for feedback; accessible focus rings.
+- Honour prefers-reduced-motion.
+*/
+
+const Modes = Object.freeze({
+  IDLE: "idle",
+  STUDY: "study",
+  BREAK: "break",
+  PAUSED: "paused",
+});
+
+const STORAGE_KEY = "studypie-state";
+const RADIUS = 90;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const STUDY_START_OFFSET = CIRCUMFERENCE * 0.5; // 180° (left)
+const FRAME_CLAMP_MS = 200;
+const BASE_LERP = 0.25;
+
+const elements = {
+  ringStudy: document.getElementById("ringStudy"),
+  ringBreak: document.getElementById("ringBreak"),
+  timer: document.getElementById("timer"),
+  studyTotal: document.getElementById("studyTotal"),
+  breakTotal: document.getElementById("breakTotal"),
+  btnStudy: document.getElementById("btnStudy"),
+  btnBreak: document.getElementById("btnBreak"),
+  btnPause: document.getElementById("btnPause"),
+  btnReset: document.getElementById("btnReset"),
+};
+
+const defaultState = {
+  mode: Modes.IDLE,
+  studyTotalMs: 0,
+  breakTotalMs: 0,
+  sessionStart: 0,
+  carriedSessionMs: 0,
+  resumeMode: null,
+};
+
+let state = { ...defaultState };
+let displayStudyRatio = 0.5;
+let lastTimestamp = null;
+let sessionStartPerf = 0;
+let lastTimerRenderSecond = null;
+let lastPersistWall = 0;
+let prefersReducedMotion = window.matchMedia
+  ? window.matchMedia("(prefers-reduced-motion: reduce)")
+  : { matches: false };
+
+const motionListener = () => {
+  // Sync immediately when preference changes so smoothing respects it.
+  if (prefersReducedMotion.matches) {
+    displayStudyRatio = getTargetStudyRatio({ wallNow: Date.now() });
+    renderRing(displayStudyRatio);
+  }
+};
+
+if (typeof prefersReducedMotion.addEventListener === "function") {
+  prefersReducedMotion.addEventListener("change", motionListener);
+} else if (typeof prefersReducedMotion.addListener === "function") {
+  prefersReducedMotion.addListener(motionListener);
+}
+
+loadState();
+applyModeClass();
+renderStatic();
+attachListeners();
+requestAnimationFrame(loop);
+
+function attachListeners() {
+  elements.btnStudy.addEventListener("click", () => startSession(Modes.STUDY));
+  elements.btnBreak.addEventListener("click", () => startSession(Modes.BREAK));
+  elements.btnPause.addEventListener("click", togglePause);
+  elements.btnReset.addEventListener("click", requestReset);
+
+  window.addEventListener("keydown", handleKeydown);
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const data = JSON.parse(raw);
+      const sanitized = {
+        mode: Object.values(Modes).includes(data.mode) ? data.mode : Modes.IDLE,
+        studyTotalMs: Number.isFinite(data.studyTotalMs) ? Math.max(0, data.studyTotalMs) : 0,
+        breakTotalMs: Number.isFinite(data.breakTotalMs) ? Math.max(0, data.breakTotalMs) : 0,
+        sessionStart: Number.isFinite(data.sessionStart) ? data.sessionStart : 0,
+        carriedSessionMs: Number.isFinite(data.carriedSessionMs) ? Math.max(0, data.carriedSessionMs) : 0,
+        resumeMode: Object.values(Modes).includes(data.resumeMode) ? data.resumeMode : null,
+      };
+
+      state = { ...defaultState, ...sanitized };
+
+      if (state.mode === Modes.PAUSED && !state.resumeMode) {
+        state.resumeMode = Modes.STUDY;
+      }
+
+      if (isActiveMode(state.mode)) {
+        // Ensure sessionStart is valid; if not, reset to now.
+        if (!state.sessionStart) {
+          const now = Date.now();
+          state.sessionStart = now;
+        }
+        syncSessionStartPerf();
+      }
+    }
+  } catch (error) {
+    console.error("Failed to parse saved StudyPie state", error);
+    state = { ...defaultState };
+  }
+
+  const total = state.studyTotalMs + state.breakTotalMs;
+  displayStudyRatio = total > 0 ? state.studyTotalMs / total : 0.5;
+}
+
+function syncSessionStartPerf() {
+  if (isActiveMode(state.mode)) {
+    const elapsed = Math.max(0, Date.now() - state.sessionStart);
+    sessionStartPerf = performance.now() - elapsed;
+  } else {
+    sessionStartPerf = 0;
+  }
+}
+
+function loop(now) {
+  if (lastTimestamp === null) {
+    lastTimestamp = now;
+  }
+
+  const rawDelta = now - lastTimestamp;
+  const clampedDelta = Math.min(rawDelta, FRAME_CLAMP_MS);
+  lastTimestamp = now;
+
+  const wallNow = Date.now();
+  updateFrame({ wallNow, delta: clampedDelta });
+
+  requestAnimationFrame(loop);
+}
+
+function updateFrame({ wallNow, delta }) {
+  const activeMode = getEffectiveMode();
+  const elapsedMs = getCurrentSessionElapsed(wallNow);
+
+  const studyDisplayMs =
+    activeMode === Modes.STUDY ? state.studyTotalMs + elapsedMs : state.studyTotalMs;
+  const breakDisplayMs =
+    activeMode === Modes.BREAK ? state.breakTotalMs + elapsedMs : state.breakTotalMs;
+
+  updateTotals(studyDisplayMs, breakDisplayMs);
+  updateTimerDisplay(elapsedMs, activeMode);
+
+  const targetRatio = getTargetStudyRatio({ wallNow, studyDisplayMs, breakDisplayMs });
+  updateDisplayRatio(targetRatio, delta);
+  renderRing(displayStudyRatio);
+
+  persistState(true, wallNow);
+}
+
+function getTargetStudyRatio({ wallNow, studyDisplayMs, breakDisplayMs }) {
+  const studyMs = studyDisplayMs ??
+    (getEffectiveMode() === Modes.STUDY ? state.studyTotalMs + getCurrentSessionElapsed(wallNow) : state.studyTotalMs);
+  const breakMs = breakDisplayMs ??
+    (getEffectiveMode() === Modes.BREAK ? state.breakTotalMs + getCurrentSessionElapsed(wallNow) : state.breakTotalMs);
+
+  const totalMs = studyMs + breakMs;
+  if (totalMs <= 0) {
+    return 0.5;
+  }
+  return Math.min(1, Math.max(0, studyMs / totalMs));
+}
+
+function updateDisplayRatio(targetRatio, delta) {
+  if (prefersReducedMotion.matches) {
+    displayStudyRatio = targetRatio;
+    return;
+  }
+
+  const frameRatio = delta / (1000 / 60);
+  const lerpFactor = 1 - Math.pow(1 - BASE_LERP, Math.max(frameRatio, 0));
+  displayStudyRatio += (targetRatio - displayStudyRatio) * lerpFactor;
+}
+
+function renderRing(ratio) {
+  const clampedRatio = Math.min(1, Math.max(0, ratio));
+  const studyLength = clampedRatio <= 0 ? 0 : clampedRatio * CIRCUMFERENCE;
+  const breakLength = clampedRatio >= 1 ? 0 : (1 - clampedRatio) * CIRCUMFERENCE;
+
+  const studyDash = studyLength > 0 ? `${studyLength} ${CIRCUMFERENCE}` : `0 ${CIRCUMFERENCE}`;
+  const breakDash = breakLength > 0 ? `${breakLength} ${CIRCUMFERENCE}` : `0 ${CIRCUMFERENCE}`;
+
+  elements.ringStudy.style.strokeDasharray = studyDash;
+  elements.ringStudy.style.strokeDashoffset = STUDY_START_OFFSET;
+
+  const breakOffset = (STUDY_START_OFFSET + studyLength) % CIRCUMFERENCE;
+  elements.ringBreak.style.strokeDasharray = breakDash;
+  elements.ringBreak.style.strokeDashoffset = breakOffset;
+}
+
+function updateTotals(studyMs, breakMs) {
+  elements.studyTotal.textContent = `Study time: ${formatHms(studyMs)}`;
+  elements.breakTotal.textContent = `Break time: ${formatHms(breakMs)}`;
+}
+
+function updateTimerDisplay(elapsedMs, activeMode) {
+  let displayedMs = elapsedMs;
+  if (!activeMode) {
+    displayedMs = 0;
+  }
+  const seconds = Math.floor(displayedMs / 1000);
+  if (seconds === lastTimerRenderSecond && activeMode) {
+    return;
+  }
+  lastTimerRenderSecond = activeMode ? seconds : null;
+  elements.timer.textContent = formatHms(displayedMs);
+}
+
+function getCurrentSessionElapsed(wallNow) {
+  const effectiveMode = getEffectiveMode();
+  if (!effectiveMode) {
+    return 0;
+  }
+  if (state.mode === Modes.PAUSED) {
+    return state.carriedSessionMs;
+  }
+  if (sessionStartPerf) {
+    const perfElapsed = Math.max(0, performance.now() - sessionStartPerf);
+    return state.carriedSessionMs + perfElapsed;
+  }
+  const sinceStart = Math.max(0, wallNow - state.sessionStart);
+  return state.carriedSessionMs + sinceStart;
+}
+
+function getEffectiveMode() {
+  if (state.mode === Modes.PAUSED) {
+    return state.resumeMode ?? null;
+  }
+  if (isActiveMode(state.mode)) {
+    return state.mode;
+  }
+  return null;
+}
+
+function isActiveMode(mode) {
+  return mode === Modes.STUDY || mode === Modes.BREAK;
+}
+
+function formatHms(ms) {
+  const totalSeconds = Math.floor(Math.max(0, ms) / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours, minutes, seconds].map((n) => String(n).padStart(2, "0")).join(":");
+}
+
+function persistState(throttled, wallNow) {
+  const now = wallNow ?? Date.now();
+  if (throttled && now - lastPersistWall < 1000) {
+    return;
+  }
+  lastPersistWall = now;
+  try {
+    const payload = {
+      mode: state.mode,
+      studyTotalMs: state.studyTotalMs,
+      breakTotalMs: state.breakTotalMs,
+      sessionStart: state.sessionStart,
+      carriedSessionMs: state.carriedSessionMs,
+      resumeMode: state.resumeMode,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.error("Failed to persist StudyPie state", error);
+  }
+}
+
+function startSession(targetMode) {
+  if (!isActiveMode(targetMode)) {
+    return;
+  }
+
+  const activeMode = getEffectiveMode();
+  if (activeMode === targetMode && state.mode !== Modes.PAUSED) {
+    return;
+  }
+
+  const wallNow = Date.now();
+  commitCurrentSession(wallNow);
+
+  state.mode = targetMode;
+  state.resumeMode = targetMode;
+  state.sessionStart = wallNow;
+  state.carriedSessionMs = 0;
+  lastTimerRenderSecond = null;
+  syncSessionStartPerf();
+  lastTimestamp = null;
+  applyModeClass();
+  persistState(false, wallNow);
+  renderStatic();
+}
+
+function commitCurrentSession(wallNow) {
+  const effectiveMode = getEffectiveMode();
+  if (!effectiveMode) {
+    state.carriedSessionMs = 0;
+    state.sessionStart = 0;
+    return;
+  }
+
+  const elapsed = getCurrentSessionElapsed(wallNow);
+  if (effectiveMode === Modes.STUDY) {
+    state.studyTotalMs += elapsed;
+  } else if (effectiveMode === Modes.BREAK) {
+    state.breakTotalMs += elapsed;
+  }
+  state.carriedSessionMs = 0;
+  state.sessionStart = 0;
+  sessionStartPerf = 0;
+  lastTimerRenderSecond = null;
+}
+
+function togglePause() {
+  if (state.mode === Modes.PAUSED) {
+    if (!state.resumeMode) {
+      return;
+    }
+    const wallNow = Date.now();
+    state.mode = state.resumeMode;
+    state.sessionStart = wallNow;
+    syncSessionStartPerf();
+    lastTimestamp = null;
+    applyModeClass();
+    persistState(false, wallNow);
+    return;
+  }
+
+  if (!isActiveMode(state.mode)) {
+    return;
+  }
+
+  const wallNow = Date.now();
+  const elapsed = Math.max(0, wallNow - state.sessionStart);
+  state.carriedSessionMs += elapsed;
+  state.mode = Modes.PAUSED;
+  state.sessionStart = 0;
+  sessionStartPerf = 0;
+  lastTimestamp = null;
+  applyModeClass();
+  persistState(false, wallNow);
+}
+
+function requestReset() {
+  const confirmed = window.confirm("Reset all StudyPie timers?");
+  if (!confirmed) {
+    return;
+  }
+  resetAll();
+}
+
+function resetAll() {
+  state = { ...defaultState };
+  displayStudyRatio = 0.5;
+  lastTimestamp = null;
+  sessionStartPerf = 0;
+  lastTimerRenderSecond = null;
+  applyModeClass();
+  persistState(false, Date.now());
+  renderStatic();
+}
+
+function handleKeydown(event) {
+  const isTypingTarget = event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLSelectElement;
+  if (isTypingTarget) {
+    return;
+  }
+
+  switch (event.key) {
+    case "s":
+    case "S":
+      event.preventDefault();
+      startSession(Modes.STUDY);
+      break;
+    case "b":
+    case "B":
+      event.preventDefault();
+      startSession(Modes.BREAK);
+      break;
+    case "r":
+    case "R":
+      event.preventDefault();
+      requestReset();
+      break;
+    case " ":
+    case "Spacebar":
+      event.preventDefault();
+      togglePause();
+      break;
+    default:
+      break;
+  }
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === "visible") {
+    lastTimestamp = null;
+    syncSessionStartPerf();
+  }
+}
+
+function applyModeClass() {
+  document.body.classList.remove("mode-idle", "mode-study", "mode-break", "mode-paused");
+  const modeForClass = state.mode;
+  document.body.classList.add(`mode-${modeForClass}`);
+}
+
+function renderStatic() {
+  const wallNow = Date.now();
+  const effectiveMode = getEffectiveMode();
+  const elapsedMs = getCurrentSessionElapsed(wallNow);
+  const studyDisplayMs =
+    effectiveMode === Modes.STUDY ? state.studyTotalMs + elapsedMs : state.studyTotalMs;
+  const breakDisplayMs =
+    effectiveMode === Modes.BREAK ? state.breakTotalMs + elapsedMs : state.breakTotalMs;
+
+  updateTotals(studyDisplayMs, breakDisplayMs);
+  updateTimerDisplay(elapsedMs, effectiveMode);
+  const targetRatio = getTargetStudyRatio({ wallNow, studyDisplayMs, breakDisplayMs });
+  displayStudyRatio = prefersReducedMotion.matches ? targetRatio : displayStudyRatio;
+  renderRing(displayStudyRatio);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StudyPie</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app" data-testid="app-root">
+      <header class="app__header">
+        <h1 class="app__logo">StudyPie</h1>
+      </header>
+      <main class="app__main" role="main">
+        <section class="board" aria-labelledby="totals-heading">
+          <h2 id="totals-heading" class="sr-only">Time overview</h2>
+          <div class="total total--break" id="breakTotal" data-testid="break-total">Break time: 00:00:00</div>
+          <div class="ring-block">
+            <div class="ring-stack">
+              <svg id="ringSvg" data-testid="ring-svg" viewBox="0 0 220 220" role="presentation" aria-hidden="true">
+                <circle class="ring-track" cx="110" cy="110" r="90"></circle>
+                <circle id="ringBreak" data-testid="ring-break" class="ring-segment ring-segment--break" cx="110" cy="110" r="90"></circle>
+                <circle id="ringStudy" data-testid="ring-study" class="ring-segment ring-segment--study" cx="110" cy="110" r="90"></circle>
+              </svg>
+              <div class="timer" id="timer" data-testid="timer" role="timer" aria-live="polite">00:00:00</div>
+            </div>
+          </div>
+          <div class="total total--study" id="studyTotal" data-testid="study-total">Study time: 00:00:00</div>
+        </section>
+        <section class="controls" aria-label="Timer controls">
+          <button id="btnStudy" data-testid="btn-study" class="control-btn control-btn--primary" type="button">Start Study</button>
+          <button id="btnBreak" data-testid="btn-break" class="control-btn" type="button">Start Break</button>
+          <button id="btnPause" data-testid="btn-pause" class="control-btn" type="button">Pause/Resume</button>
+          <button id="btnReset" data-testid="btn-reset" class="control-btn control-btn--danger" type="button">Reset</button>
+        </section>
+      </main>
+    </div>
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,302 @@
+:root {
+  --red: #f73d3f;
+  --green: #b9e7b1;
+  --bg: #f7f7fa;
+  --fg: #111;
+  --ringThickness: 26;
+  --ringSize: clamp(15rem, 45vw, 26rem);
+  --btn-radius: 999px;
+  --shadow-soft: 0 12px 28px rgba(17, 17, 17, 0.08);
+  --shadow-press: 0 6px 16px rgba(17, 17, 17, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+  display: flex;
+  justify-content: center;
+}
+
+.app {
+  min-height: 100vh;
+  width: min(960px, 100vw);
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 6vw, 3.5rem);
+}
+
+.app__header {
+  display: flex;
+  justify-content: center;
+}
+
+.app__logo {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.app__main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3.5rem);
+}
+
+.board {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-areas: "break ring study";
+  align-items: center;
+  gap: clamp(1.5rem, 5vw, 3rem);
+}
+
+.total {
+  font-size: clamp(1rem, 2.6vw, 1.25rem);
+  letter-spacing: 0.01em;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 1.25rem;
+  padding: 0.75rem 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(17, 17, 17, 0.05);
+  backdrop-filter: blur(6px);
+}
+
+.total--break {
+  grid-area: break;
+  justify-self: end;
+  text-align: right;
+}
+
+.total--study {
+  grid-area: study;
+  justify-self: start;
+}
+
+.ring-block {
+  grid-area: ring;
+  justify-self: center;
+}
+
+.ring-stack {
+  position: relative;
+  width: var(--ringSize);
+  aspect-ratio: 1;
+}
+
+#ringSvg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.ring-track,
+.ring-segment {
+  fill: none;
+  stroke-width: var(--ringThickness);
+}
+
+.ring-track {
+  stroke: rgba(17, 17, 17, 0.08);
+}
+
+.ring-segment {
+  stroke-linecap: butt;
+  stroke-dasharray: 0 999;
+  transform-origin: 50% 50%;
+  transition: stroke-width 180ms ease, stroke 180ms ease;
+}
+
+.ring-segment--study {
+  stroke: var(--red);
+}
+
+.ring-segment--break {
+  stroke: var(--green);
+}
+
+.timer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(2.25rem, 6vw, 3.75rem);
+  font-weight: 600;
+  color: var(--fg);
+  text-align: center;
+  pointer-events: none;
+  transition: color 180ms ease;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.control-btn {
+  position: relative;
+  padding: 0.85rem 1.8rem;
+  border: none;
+  border-radius: var(--btn-radius);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--fg);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 200ms ease, color 200ms ease;
+  will-change: transform;
+  overflow: hidden;
+}
+
+.control-btn::after {
+  content: "";
+  position: absolute;
+  inset: 50% 0 0 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.5);
+  transition: none;
+  pointer-events: none;
+}
+
+.control-btn:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 16px 36px rgba(17, 17, 17, 0.12);
+}
+
+.control-btn:active {
+  transform: scale(0.97);
+  box-shadow: var(--shadow-press);
+}
+
+.control-btn:active::after {
+  width: 220%;
+  height: 220%;
+  opacity: 0.12;
+  transition: opacity 220ms ease, transform 220ms ease;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.control-btn:focus-visible {
+  outline: 3px solid rgba(17, 17, 17, 0.6);
+  outline-offset: 3px;
+}
+
+.control-btn--primary {
+  background: var(--red);
+  color: #fff;
+}
+
+.control-btn--primary:hover {
+  box-shadow: 0 18px 40px rgba(247, 61, 63, 0.3);
+}
+
+.control-btn--primary:active {
+  box-shadow: 0 12px 28px rgba(247, 61, 63, 0.35);
+}
+
+.control-btn--danger {
+  background: rgba(247, 61, 63, 0.12);
+  color: var(--red);
+}
+
+#btnBreak {
+  background: rgba(185, 231, 177, 0.28);
+  color: #1b4415;
+}
+
+#btnBreak:hover {
+  box-shadow: 0 18px 40px rgba(64, 121, 54, 0.18);
+}
+
+#btnBreak:active {
+  box-shadow: 0 12px 28px rgba(64, 121, 54, 0.22);
+}
+
+body.mode-study .timer {
+  color: var(--red);
+}
+
+body.mode-break .timer {
+  color: #2e6930;
+}
+
+body.mode-paused .timer {
+  color: rgba(17, 17, 17, 0.6);
+}
+
+body.mode-idle .timer {
+  color: rgba(17, 17, 17, 0.75);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 820px) {
+  .board {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "ring"
+      "break"
+      "study";
+    justify-items: center;
+  }
+
+  .total {
+    width: min(100%, 22rem);
+    text-align: center;
+  }
+
+  .total--break {
+    justify-self: center;
+  }
+
+  .total--study {
+    justify-self: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .control-btn::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add the StudyPie single-page layout with ring visual, totals, and controls
- implement high-fidelity timing loop with persistence, keyboard shortcuts, and smooth SVG ring rendering
- style the experience for responsive layouts with tactile button feedback and reduced-motion support

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd3c917ef48329916ed0264d41d65b