### PR TITLE
Load Inter font and refine timer typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>StudyPie</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/styles.css
+++ b/styles.css
@@ -22,11 +22,15 @@ body {
 body {
   margin: 0;
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
   background: var(--bg);
   color: var(--fg);
   line-height: 1.5;
   display: flex;
   justify-content: center;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 .app {
@@ -138,6 +142,7 @@ body {
   font-weight: 600;
   color: var(--fg);
   text-align: center;
+  font-variant-numeric: tabular-nums;
   pointer-events: none;
   transition: color 180ms ease;
 }


### PR DESCRIPTION
## Summary
- load the Inter font from Google Fonts so the UI matches the reference mockups across machines
- tweak global typography to use tabular numbers and improved smoothing for timer digits

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd4885c7708329b7b132cc0eb5d7d2