### PR TITLE
Adjust global hotkeys to respect modifiers and focused controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -375,8 +375,11 @@ function resetAll() {
 }
 
 function handleKeydown(event) {
-  const isTypingTarget = event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLSelectElement;
-  if (isTypingTarget) {
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return;
+  }
+
+  if (shouldSkipGlobalHotkey(event.target)) {
     return;
   }
 
@@ -404,6 +407,31 @@ function handleKeydown(event) {
     default:
       break;
   }
+}
+
+function shouldSkipGlobalHotkey(target) {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const interactiveSelector =
+    "input, textarea, select, button, a[href], [role='button'], [role='link']";
+  if (target.closest(interactiveSelector)) {
+    return true;
+  }
+
+  let current = target;
+  while (current) {
+    if (current.isContentEditable) {
+      return true;
+    }
+    if (current.hasAttribute("tabindex") && current.tabIndex >= 0) {
+      return true;
+    }
+    current = current.parentElement;
+  }
+
+  return false;
 }
 
 function handleVisibilityChange() {


### PR DESCRIPTION
## Summary
- return early in the global key handler when modifier keys are pressed so browser/system shortcuts work normally
- detect focused interactive controls before handling StudyPie hotkeys to let native button activation proceed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ced638083298c067435fae27725