### PR TITLE
Refine total display structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,8 @@ const elements = {
   timer: document.getElementById("timer"),
   studyTotal: document.getElementById("studyTotal"),
   breakTotal: document.getElementById("breakTotal"),
+  studyTotalValue: document.querySelector("#studyTotal .total__value"),
+  breakTotalValue: document.querySelector("#breakTotal .total__value"),
   btnStudy: document.getElementById("btnStudy"),
   btnBreak: document.getElementById("btnBreak"),
   btnPause: document.getElementById("btnPause"),
@@ -320,8 +322,17 @@ function renderRing(ratio) {
 }
 
 function updateTotals(studyMs, breakMs) {
-  elements.studyTotal.textContent = `Study time:\n${formatHms(studyMs)}`;
-  elements.breakTotal.textContent = `Break time:\n${formatHms(breakMs)}`;
+  if (elements.studyTotalValue) {
+    elements.studyTotalValue.textContent = formatHms(studyMs);
+  } else if (elements.studyTotal) {
+    elements.studyTotal.textContent = `Study time:\n${formatHms(studyMs)}`;
+  }
+
+  if (elements.breakTotalValue) {
+    elements.breakTotalValue.textContent = formatHms(breakMs);
+  } else if (elements.breakTotal) {
+    elements.breakTotal.textContent = `Break time:\n${formatHms(breakMs)}`;
+  }
 }
 
 function updateTimerDisplay(elapsedMs, activeMode) {

--- a/index.html
+++ b/index.html
@@ -41,7 +41,10 @@
       <main class="app__main" role="main">
         <section class="board" aria-labelledby="totals-heading">
           <h2 id="totals-heading" class="sr-only">Time overview</h2>
-          <div class="total total--break" id="breakTotal" data-testid="break-total">Break time:&#10;00:00:00</div>
+          <div class="total total--break" id="breakTotal" data-testid="break-total">
+            <span class="total__label">Break time:</span>
+            <span class="total__value">00:00:00</span>
+          </div>
           <div class="ring-block">
             <div class="ring-stack">
               <svg id="ringSvg" data-testid="ring-svg" viewBox="0 0 220 220" role="presentation" aria-hidden="true">
@@ -52,7 +55,10 @@
               <div class="timer" id="timer" data-testid="timer" role="timer" aria-live="polite">00:00:00</div>
             </div>
           </div>
-          <div class="total total--study" id="studyTotal" data-testid="study-total">Study time:&#10;00:00:00</div>
+          <div class="total total--study" id="studyTotal" data-testid="study-total">
+            <span class="total__label">Study time:</span>
+            <span class="total__value">00:00:00</span>
+          </div>
         </section>
         <section class="controls" aria-label="Timer controls">
           <button id="btnStudy" data-testid="btn-study" class="control-btn control-btn--primary" type="button">Start Study</button>

--- a/styles.css
+++ b/styles.css
@@ -264,13 +264,16 @@ body {
   box-shadow: inset 0 0 0 1px var(--surface-border);
   backdrop-filter: blur(6px);
   transition: background-color 260ms ease, color 260ms ease, box-shadow 260ms ease;
-  white-space: pre-line;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  text-align: center;
 }
 
 .total--break {
   grid-area: break;
   justify-self: end;
-  text-align: right;
 }
 
 .total--study {


### PR DESCRIPTION
## Summary
- wrap the break and study totals in dedicated label/value spans in the markup
- update the totals renderer to write into the new value spans while keeping a fallback
- restyle the total cards to stack label/value vertically and center align the values

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d00a2b93dc8329a2a93c98c59d1e59